### PR TITLE
refactor error handling to use thiserror

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,6 @@ keywords = ["ssb", "scuttlebutt"]
 log = "0.4.8"
 bytes = "0.5.3"
 byteorder = "1.3.2"
-failure = "0.1.6"
 pretty_env_logger = "0.3.1"
 serde = "1.0.104"
 serde_derive = "1.0.104"
@@ -24,6 +23,7 @@ serde_cbor = "0.10.2"
 buffered_offset_reader = "0.6.0"
 bidir_iter = "0.2.1"
 ssb-multiformats = "0.4.1"
+thiserror = "1.0.40"
 
 [dev-dependencies]
 criterion = "0.3.0"

--- a/src/flume_log.rs
+++ b/src/flume_log.rs
@@ -1,4 +1,4 @@
-pub use failure::Error;
+use std::error::Error;
 
 pub struct StreamOpts {
     pub lt: String,
@@ -8,17 +8,13 @@ pub struct StreamOpts {
     pub limit: usize,
 }
 
-#[derive(Debug, Fail)]
-pub enum FlumeLogError {
-    #[fail(display = "Unable to find sequence: {}", sequence)]
-    SequenceNotFound { sequence: u64 },
-}
-
 pub type Sequence = u64;
 
 pub trait FlumeLog {
-    fn get(&self, seq: Sequence) -> Result<Vec<u8>, Error>;
+    type Error: Error;
+
+    fn get(&self, seq: Sequence) -> Result<Vec<u8>, Self::Error>;
     fn clear(&mut self, seq: Sequence);
     fn latest(&self) -> Option<Sequence>;
-    fn append(&mut self, buff: &[u8]) -> Result<Sequence, Error>;
+    fn append(&mut self, buff: &[u8]) -> Result<Sequence, Self::Error>;
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,15 +7,13 @@ extern crate buffered_offset_reader;
 extern crate byteorder;
 extern crate bytes;
 #[macro_use]
-extern crate failure;
 extern crate log;
 extern crate serde;
 #[macro_use]
 extern crate serde_derive;
-extern crate serde_json;
 extern crate serde_cbor;
+extern crate serde_json;
 extern crate ssb_multiformats;
-
 
 pub mod flume_log;
 pub mod flume_view;


### PR DESCRIPTION
did as part of [`ssb-archive`](https://github.com/ahdinosaur/ssb-archive)

- changed error enums from using `failure` to using `thiserror`.
  - this changes what the functions return, previously `failure::Error`, now they return an error enum, e.g. `FlumeOffsetLogError`.
- added error variants for source errors that were previously handled automatically
  - i decided to make specific variants for each situation, rather than for example just having an `Io(#[from] std::io::Error)` variant.
- changed the `FlumeLog` trait to take an associated type `Error`.

open to feedback on the best way to do this.